### PR TITLE
UI Profiles

### DIFF
--- a/GameScreen.cs
+++ b/GameScreen.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using DeepFreeze.Events;
 using UnityEngine;
-using UnityEngine.Events;
 
 namespace DeepFreeze.ScreenSystem
 {

--- a/ScreenManager.cs
+++ b/ScreenManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using DeepFreeze.Events;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
 using Object = UnityEngine.Object;
 
 namespace DeepFreeze.ScreenSystem
@@ -88,7 +89,7 @@ namespace DeepFreeze.ScreenSystem
             _screenProvider = screenProvider;
             await UniTask.WaitUntil(() => _screenProvider.Initialized);
 
-            SpawnPopupContainers();
+            await SpawnPopupContainers();
             BindEvents();
 
             Initialized = true;
@@ -150,14 +151,15 @@ namespace DeepFreeze.ScreenSystem
             Profile = profile;
         }
 
-        private static void SpawnPopupContainers()
+        private static async Task SpawnPopupContainers()
         {
             PopupControllers.Clear();
 
             foreach (var priority in Enum.GetValues(typeof(PopupPriority)))
             {
                 var priorityValue = (PopupPriority)priority;
-                var newController = Object.Instantiate(Profile.popupCanvasControllerPrefab);
+                var newControllerObj = await Addressables.InstantiateAsync(Profile.popupCanvasControllerPrefab);
+                var newController = newControllerObj.GetComponent<PopupCanvasController>();
                 newController.Initialize(priorityValue);
                 PopupControllers.Add(priorityValue, newController);
                 Object.DontDestroyOnLoad(newController.gameObject);

--- a/ScreenProfile.cs
+++ b/ScreenProfile.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using UnityEngine;
+
+namespace DeepFreeze.ScreenSystem
+{
+    [Serializable]
+    public class ScreenProfile
+    {
+        public string id = "NewProfile";
+        
+        public string constantScreenPrefix;
+        public string constantPopupPrefix;
+        
+        [Space]
+        public string screenPrefixPort = "Screen_Port_";
+        public string screenPrefixLand = "Screen_Land_";
+        public string screenSuffix = "";
+        public string popupPrefixPort = "Popup_Port_";
+        public string popupPrefixLand = "Popup_Land_";
+        public string popupSuffix = "";
+
+        [Space]
+        public PopupCanvasController popupCanvasControllerPrefab;
+    }
+}

--- a/ScreenProfile.cs
+++ b/ScreenProfile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
 
 namespace DeepFreeze.ScreenSystem
 {
@@ -20,6 +21,6 @@ namespace DeepFreeze.ScreenSystem
         public string popupSuffix = "";
 
         [Space]
-        public PopupCanvasController popupCanvasControllerPrefab;
+        public AssetReferenceGameObject popupCanvasControllerPrefab;
     }
 }

--- a/ScreenProfile.cs.meta
+++ b/ScreenProfile.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 57c6bff03ae94913a588ea5bb2a089e0
+timeCreated: 1698251415

--- a/ScreenSettings.cs
+++ b/ScreenSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace DeepFreeze.ScreenSystem
@@ -6,19 +7,7 @@ namespace DeepFreeze.ScreenSystem
     [Serializable]
     public partial class ScreenSettings
     {
-        public string constantScreenPrefix;
-        public string constantPopupPrefix;
-        
-        [Space]
-        public string screenPrefixPort = "Screen_Port_";
-        public string screenPrefixLand = "Screen_Land_";
-        public string screenSuffix = "";
-        public string popupPrefixPort = "Popup_Port_";
-        public string popupPrefixLand = "Popup_Land_";
-        public string popupSuffix = "";
-
-        [Space]
-        public PopupCanvasController popupCanvasControllerPrefab;
+        public List<ScreenProfile> profiles = new();
 
         [Space] 
         public bool logScreenSpawned;


### PR DESCRIPTION
# What
Created a profile system for UI management to make it easier to add multiplatform UI. This system allows you to create specific profiles for each platform that can then be manually set during initialization. Profiles will augment what addressables address is used to look up the UI. You can then use a custom naming convention to handle these lookups. This system is not currently automated (on purpose) as there is very little overhead setting the profiles up manually and a high chance that an automated system would get in the way more than it would help. All profiles are stored in the screen settings class. The popup canvas controller reference has been changed to an addressable reference to prevent pulling all UI packs unnecessarily. 